### PR TITLE
fix/set httponly to false

### DIFF
--- a/waffleAuth/views.py
+++ b/waffleAuth/views.py
@@ -89,7 +89,6 @@ def set_response(accept):
     accept_status = accept.status_code
     # not accepted
     if accept_status != 200:
-        print(accept)
         return JsonResponse({"err_msg": "failed to signup"}, status=accept_status)
 
     # accepted
@@ -100,8 +99,6 @@ def set_response(accept):
     data = json.loads(content)
     access_token = data.get("access")
     refresh_token = data.get("refresh")
-    print("\naccess token:", access_token)
-    print("\nrefresh token:", refresh_token)
 
     # response가 access token만 포함하도록 변경
     response_data = {"access": access_token}
@@ -143,7 +140,6 @@ def kakao_callback(request):
     profile_json = profile_request.json()
 
     kakao_account = profile_json.get("kakao_account")
-    print("\nprofile:", profile_json)
 
     data = {"access_token": access_token, "code": code}
     accept = requests.post(f"{BASE_URL}auth/kakao/login/finish/", data=data)

--- a/waffleAuth/views.py
+++ b/waffleAuth/views.py
@@ -35,7 +35,7 @@ class CookieTokenObtainPairView(TokenObtainPairView):
             response.set_cookie(
                 "refresh_token",
                 refresh_token,
-                httponly=True,
+                httponly=False,
                 samesite="None",
             )
 
@@ -56,7 +56,7 @@ class CookieTokenRefreshView(TokenRefreshView):
             response.set_cookie(
                 "refresh_token",
                 refresh_token,
-                httponly=True,
+                httponly=False,
                 samesite="None",
             )
 
@@ -68,6 +68,7 @@ state = os.environ.get("STATE")
 BASE_URL = os.environ.get("BASE_URL")
 KAKAO_CALLBACK_URI = BASE_URL + "auth/kakao/callback/"
 NAVER_CALLBACK_URI = BASE_URL + "auth/naver/callback/"
+REDIRECT_URI = BASE_URL + "auth/"
 
 
 def kakao_login(request):
@@ -110,7 +111,7 @@ def set_response(accept):
         response.set_cookie(
             "refresh_token",
             refresh_token,
-            httponly=True,
+            httponly=False,
             samesite="None",
         )
 
@@ -198,16 +199,6 @@ def naver_callback(request):
     #     return set_response(accept)
 
 
-REDIRECT_URI = BASE_URL + "auth/"
-
-
-def kakao_logout(request):
-    client_id = os.environ.get("SOCIAL_AUTH_KAKAO_CLIENT_ID")
-    return redirect(
-        f"https://kauth.kakao.com/oauth/logout?client_id={client_id}&logout_redirect_uri={REDIRECT_URI}"
-    )
-
-
 class KakaoLogout(TokenBlacklistView):
     def post(self, request, *args, **kwargs):
         response = super().post(request, *args, **kwargs)
@@ -232,18 +223,6 @@ class NaverLogout(TokenBlacklistView):
         )
 
         return response
-
-
-def naver_logout(request):
-    client_id = os.environ.get("SOCIAL_AUTH_NAVER_CLIENT_ID")
-    client_secret = os.environ.get("SOCIAL_AUTH_NAVER_SECRET")
-    access_token = request.GET.get("access_token")
-    return redirect(
-        f"https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id={client_id}&client_secret={client_secret}&access_token={access_token}&service_provider=NAVER"
-    )
-
-
-
 
 class KakaoLogin(SocialLoginView):
     adapter_class = kakao_view.KakaoOAuth2Adapter


### PR DESCRIPTION
+ refact/erase unused codes
+ refact/erase print method

쿠키에서 refresh token을 가져오는 것이 생각보다 작업량이 많아서 우선 httponly=False로 설정하고, refresh token을 res body에 받는 방식으로 구현하려고 합니다. 이에 더해 waffleAuth view에서 쓰지 않는 코드들을 정리했습니다.