### PR TITLE
Fix/logout request type 

### DIFF
--- a/userprofile/serializers.py
+++ b/userprofile/serializers.py
@@ -30,6 +30,11 @@ class UserDetailSerializer(serializers.ModelSerializer):
         instance.save()
         return instance
 
+class UserDeleteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = WaffleUser
+        fields = ['id']
+
 
 class CommentSerializer(serializers.ModelSerializer):
     class Meta:

--- a/userprofile/urls.py
+++ b/userprofile/urls.py
@@ -7,6 +7,7 @@ from .views import *
 urlpatterns = [
     path('mypage/', UserMyPageDetailView.as_view(), name='user-detail'),
     path('<int:pk>/', UserDetailView.as_view(), name='user-detail'),
+    #path('<int:user_id>/delete/', UserMyPageDetailView.as_view(), name='user-detail'),
     path('<int:user_id>/followers/', FollowersListView.as_view(), name='user-followers'),
     path('<int:user_id>/followings/', FollowingsListView.as_view(), name='user-following'),
     path('<int:user_id>/add/follow/', AddFollowView.as_view(), name='user-add-follow-by-detail-page'),
@@ -16,5 +17,4 @@ urlpatterns = [
     path('<int:user_id>/movies/watching/', UserMovieStateListView.as_view(), {'state': 'watching'}, name='user-watching-movies'),
     path('<int:user_id>/movies/want_to_watch/', UserMovieStateListView.as_view(), {'state': 'want_to_watch'}, name='user-want-to-watch-movies'),
     path('<int:user_id>/movies/not_interested/', UserMovieStateListView.as_view(), {'state': 'not_interested'}, name='user-not-interested-movies'),
-
     ]

--- a/userprofile/urls.py
+++ b/userprofile/urls.py
@@ -6,8 +6,8 @@ from .views import *
 
 urlpatterns = [
     path('mypage/', UserMyPageDetailView.as_view(), name='user-detail'),
+    path('mypage/delete/', UserMyPageDeleteView.as_view(), name='user-detail'),
     path('<int:pk>/', UserDetailView.as_view(), name='user-detail'),
-    #path('<int:user_id>/delete/', UserMyPageDetailView.as_view(), name='user-detail'),
     path('<int:user_id>/followers/', FollowersListView.as_view(), name='user-followers'),
     path('<int:user_id>/followings/', FollowingsListView.as_view(), name='user-following'),
     path('<int:user_id>/add/follow/', AddFollowView.as_view(), name='user-add-follow-by-detail-page'),

--- a/userprofile/urls.py
+++ b/userprofile/urls.py
@@ -6,7 +6,7 @@ from .views import *
 
 urlpatterns = [
     path('mypage/', UserMyPageDetailView.as_view(), name='user-detail'),
-    path('mypage/delete/', UserMyPageDeleteView.as_view(), name='user-detail'),
+    path('mypage/delete/', UserMyPageDeleteView.as_view(), name='user-delete'),
     path('<int:pk>/', UserDetailView.as_view(), name='user-detail'),
     path('<int:user_id>/followers/', FollowersListView.as_view(), name='user-followers'),
     path('<int:user_id>/followings/', FollowingsListView.as_view(), name='user-following'),

--- a/userprofile/views.py
+++ b/userprofile/views.py
@@ -3,7 +3,7 @@ from waffleAuth.models import WaffleUser
 from content.models import Movie, Rating, State
 from comment.models import Comment, Like
 # Create your views here.
-from rest_framework.generics import RetrieveAPIView, ListAPIView, RetrieveUpdateAPIView
+from rest_framework.generics import RetrieveAPIView, ListAPIView, RetrieveUpdateDestroyAPIView
 from .serializers import StateSerializer, UserRatingSerializer, CommentSerializer, UserDetailSerializer, UserSerializer
 from rest_framework.permissions import IsAuthenticated
 from rest_framework_simplejwt.authentication import JWTAuthentication
@@ -21,13 +21,17 @@ class UserDetailView(RetrieveAPIView):
     lookup_field = 'pk'
 
 
-class UserMyPageDetailView(RetrieveUpdateAPIView):
+class UserMyPageDetailView(RetrieveUpdateDestroyAPIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
     serializer_class = UserDetailSerializer
 
     def get_object(self):
         return self.request.user
+
+    def perform_destroy(self, instance):
+        user = WaffleUser.objects.get(id=self.request.user.id)
+        user.delete()
 
 
 class AddFollowView(APIView):

--- a/userprofile/views.py
+++ b/userprofile/views.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework_simplejwt.views import TokenBlacklistView
-from django.http import JsonResponse
+from django.http import JsonResponse, QueryDict
 
 
 class UserDetailView(RetrieveAPIView):
@@ -51,9 +51,11 @@ class UserMyPageDeleteView(DestroyAPIView, TokenBlacklistView):
 
     def post(self, request, *args, **kwargs):
         org_refresh_token = request.COOKIES.get('refresh_token')
-        request.data._mutable = True
+        if isinstance(request.data, QueryDict):
+            request.data._mutable = True
         request.data["refresh"] = org_refresh_token
-        request.data._mutable = False
+        if isinstance(request.data, QueryDict):
+            request.data._mutable = False
         super().post(request, *args, **kwargs)
         response_data = {"message": "tokens deleted"}
         response = JsonResponse(response_data)

--- a/waffleAuth/urls.py
+++ b/waffleAuth/urls.py
@@ -22,7 +22,7 @@ urlpatterns = [
         CookieTokenRefreshView.as_view(),
         name="token_refresh",
     ),
-    path("token/logout/", TokenBlacklistView.as_view(), name="token_blacklist"),
+    path("token/logout/", CustomTokenBlacklistView.as_view(), name="token_blacklist"),
     # for registration
     path("register/", include("dj_rest_auth.registration.urls")),
     path("token/register/", CustomRegisterView.as_view(), name='custom-register'),

--- a/waffleAuth/views.py
+++ b/waffleAuth/views.py
@@ -67,9 +67,11 @@ class CookieTokenObtainPairView(TokenObtainPairView):
 class CookieTokenRefreshView(TokenRefreshView):
     def post(self, request, *args, **kwargs):
         org_refresh_token = request.COOKIES.get('refresh_token')
-        request.data._mutable = True
+        if isinstance(request.data, QueryDict):
+            request.data._mutable = True
         request.data["refresh"] = org_refresh_token
-        request.data._mutable = False
+        if isinstance(request.data, QueryDict):
+            request.data._mutable = False
         response_data = super().post(request, *args, **kwargs).data
         access_token = response_data.get("access")
         refresh_token = response_data.get("refresh")

--- a/waffleAuth/views.py
+++ b/waffleAuth/views.py
@@ -16,7 +16,7 @@ import os
 from rest_framework_simplejwt.views import TokenObtainPairView
 from rest_framework_simplejwt.views import TokenRefreshView
 from rest_framework_simplejwt.views import TokenBlacklistView
-from django.http import JsonResponse
+from django.http import JsonResponse, QueryDict
 import json
 
 from dj_rest_auth.registration.views import RegisterView
@@ -95,9 +95,11 @@ class CookieTokenRefreshView(TokenRefreshView):
 class CustomTokenBlacklistView(TokenBlacklistView):
     def post(self, request, *args, **kwargs):
         org_refresh_token = request.COOKIES.get('refresh_token')
-        request.data._mutable = True
+        if isinstance(request.data, QueryDict):
+            request.data._mutable = True
         request.data["refresh"] = org_refresh_token
-        request.data._mutable = False
+        if isinstance(request.data, QueryDict):
+            request.data._mutable = False
         super().post(request, *args, **kwargs)
         response_data = {"message": "logout succeed"}
         response = JsonResponse(response_data)

--- a/waffleAuth/views.py
+++ b/waffleAuth/views.py
@@ -245,11 +245,11 @@ def naver_callback(request):
 
 class KakaoLogout(TokenBlacklistView):
     def post(self, request, *args, **kwargs):
-        response = super().post(request, *args, **kwargs)
-
         client_id = os.environ.get("SOCIAL_AUTH_KAKAO_CLIENT_ID")
-        redirect(
-            f"https://kauth.kakao.com/oauth/logout?client_id={client_id}&logout_redirect_uri={REDIRECT_URI}"
+        redirect_uri = os.environ.get("KAKAO_REDIRECT_URI")
+
+        response = redirect(
+            f"https://kauth.kakao.com/oauth/logout?client_id={client_id}&logout_redirect_uri={redirect_uri}"
         )
 
         return response

--- a/waffleAuth/views.py
+++ b/waffleAuth/views.py
@@ -18,19 +18,16 @@ from rest_framework_simplejwt.views import TokenRefreshView
 from rest_framework_simplejwt.views import TokenBlacklistView
 from django.http import JsonResponse
 import json
-from dj_rest_auth.registration.views import RegisterView
-from dj_rest_auth.app_settings import api_settings
 
 from dj_rest_auth.registration.views import RegisterView
-from dj_rest_auth.registration.views import LoginView
 from dj_rest_auth.app_settings import api_settings
-from rest_framework_simplejwt.serializers import TokenBlacklistSerializer
 
 COOKIE_DURATION = 86400
 
 
 class CustomRegisterView(RegisterView):
     serializer_class = CustomRegisterSerializer
+
     def get_response_data(self, user):
         response_data = super().get_response_data(user)
 
@@ -94,6 +91,7 @@ class CookieTokenRefreshView(TokenRefreshView):
 
         return response
 
+
 class CustomTokenBlacklistView(TokenBlacklistView):
     def post(self, request, *args, **kwargs):
         org_refresh_token = request.COOKIES.get('refresh_token')
@@ -113,7 +111,6 @@ BASE_URL = os.environ.get("BASE_URL")
 KAKAO_CALLBACK_URI = os.environ.get("KAKAO_CALLBACK_URI")
 NAVER_CALLBACK_URI = BASE_URL + "auth/naver/callback/"
 REDIRECT_URI = BASE_URL + "auth/"
-
 
 
 def kakao_login(request):
@@ -268,6 +265,7 @@ class NaverLogout(TokenBlacklistView):
 
         return response
 
+
 class KakaoLogin(SocialLoginView):
     adapter_class = kakao_view.KakaoOAuth2Adapter
     callback_url = KAKAO_CALLBACK_URI
@@ -284,6 +282,7 @@ class NaverLogin(SocialLoginView):
 class MyProtectedView(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
+
 
     def get(self, request):
         response = JsonResponse({"message": "You are authenticated"})


### PR DESCRIPTION
로그아웃 시 크롬 브라우저를 이용하면 querydict로 request.data가 들어오고, postman을 이용하면 dict로 request.data가 들어와서 두 개를 모두 다룰 수 있도록 코드 변경했습니다.

탈퇴 시에 token들도 같이 만료/삭제 되도록 구현했습니다.