### PR TITLE
feat/Create my_comment field

### DIFF
--- a/content/serializers.py
+++ b/content/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from .models import *
+from comment.models import Comment
 from .validators import decimal_choices_validator
 
 
@@ -30,6 +31,7 @@ class MovieSerializer(serializers.ModelSerializer):
     genres = ShowGenreSerializer(many=True)
     average_rate = serializers.SerializerMethodField()
     my_rate = serializers.SerializerMethodField()
+    my_comment = serializers.SerializerMethodField()
 
     class Meta:
         model = Movie
@@ -49,6 +51,17 @@ class MovieSerializer(serializers.ModelSerializer):
                 context = dict()
                 context['id'] = my_rating.id
                 context['my_rate'] = my_rating.rate
+                return context
+        return None
+
+    def get_my_comment(self, obj):
+        request = self.context.get('request')
+        if request.user.is_authenticated:
+            if Comment.objects.filter(movie=obj, created_by=request.user).exists():
+                my_comment_obj = Comment.objects.get(movie=obj, created_by=request.user)
+                context = dict()
+                context['id'] = my_comment_obj.id
+                context['my_comment'] = my_comment_obj.content
                 return context
         return None
 


### PR DESCRIPTION
get_my_rate와 같은 방식으로 작업했습니다! comment 작성 시 영화 상세보기에 comment_id와 content, 없으면 null이 표시됩니다.

그런데 테스트 위해 코멘트 작성을 하고 상세보기 GET을 하니, 500 에러가 뜨더군요?? 

comment.models.Comment.DoesNotExist: Comment matching query does not exist.

요 에러인데, 몇 분 뒤 다시 시도해보니 정상 동작했습니다. 그냥 데이터 반영 딜레이의 문제였을지...?
그런데 지금 조건문 통과 못하면 return None으로 처리해줬으므로, query가 없다고 해도 이런 에러가 뜨면 안 될 거 같은데, 혹시 요게 지금 프론트에서 말하는 500 에러에 대한 단서가 될 수 있을까 하여 남겨봅니다