### PR TITLE
Fix/admin bypass issue

### DIFF
--- a/content/serializers.py
+++ b/content/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from .models import *
 from comment.models import Comment
+from comment.serializers import CommentSerializer
 from .validators import decimal_choices_validator
 
 
@@ -59,11 +60,8 @@ class MovieSerializer(serializers.ModelSerializer):
         if request.user.is_authenticated:
             if Comment.objects.filter(movie=obj, created_by=request.user).exists():
                 my_comment_obj = Comment.objects.get(movie=obj, created_by=request.user)
-                context = dict()
-                context['id'] = my_comment_obj.id
-                context['my_comment'] = my_comment_obj.content
-                context['has_spoiler'] = my_comment_obj.has_spoiler
-                return context
+                serializer = CommentSerializer(my_comment_obj, context={'request': request})
+                return serializer.data
         return None
 
 


### PR DESCRIPTION
- 적용이 제대로 안 돼서 찾아보니 constraints 설정은 DB 단에서만 설정해 준 거라 admin에서 바로 주입할 때는 unique가 문제없이 작동했는데, view를 통해서 넣는 게 적용이 안 되고 있었습니다. perform_create() override로 해결했습니다.
- FE 요청에 따라 영화 상세보기 안의 my_comment를 comment serializer 구조와 똑같이 맞춰줬습니다.