### PR TITLE
Fix/fix authentication classes

### DIFF
--- a/comment/serializers.py
+++ b/comment/serializers.py
@@ -55,6 +55,7 @@ class ReplyCommentSerializer(serializers.ModelSerializer):
 class ReplySerializer(serializers.ModelSerializer):
     created_by = WriterSerializer(read_only=True)
     like_count = serializers.SerializerMethodField()
+    liked_by_user = serializers.SerializerMethodField()
     comment = ReplyCommentSerializer(read_only=True)
 
     class Meta:
@@ -63,3 +64,10 @@ class ReplySerializer(serializers.ModelSerializer):
 
     def get_like_count(self, obj):
         return obj.likes.all().count()
+
+    def get_liked_by_user(self, obj):
+        request = self.context.get('request')
+        if request.user.is_authenticated:
+            if obj.likes.filter(created_by=request.user).exists():
+                return True
+        return False

--- a/comment/views.py
+++ b/comment/views.py
@@ -57,6 +57,13 @@ class CommentListCreateAPI(generics.ListCreateAPIView):
                 movie=movie
             )
 
+            # connect Comment to Rating if exists
+            if Rating.objects.filter(movie=movie, created_by=self.request.user).exists():
+                current_rating = Rating.objects.get(movie=movie, created_by=self.request.user)
+                user_comment = Comment.objects.get(movie=movie, created_by=self.request.user)
+                user_comment.rating = current_rating
+                user_comment.save()
+
 
 class CommentRetrieveUpdateDestroyAPI(generics.RetrieveUpdateDestroyAPIView):
     queryset = Comment.objects.all()
@@ -66,6 +73,9 @@ class CommentRetrieveUpdateDestroyAPI(generics.RetrieveUpdateDestroyAPIView):
 
 
 class ProcessCommentLikeAPI(APIView):
+    authentication_classes = [JWTAuthentication,]
+    permission_classes = [IsOwnerOrReadOnly,]
+
     def post(self, request, *args, **kwargs):
         like, created = Like.objects.get_or_create(
             created_by=self.request.user,
@@ -107,6 +117,9 @@ class ReplyRetrieveUpdateDestroyAPI(generics.RetrieveUpdateDestroyAPIView):
 
 
 class ProcessReplyLikeAPI(APIView):
+    authentication_classes = [JWTAuthentication,]
+    permission_classes = [IsOwnerOrReadOnly,]
+
     def post(self, request, *args, **kwargs):
         like, created = Like.objects.get_or_create(
             created_by=self.request.user,

--- a/comment/views.py
+++ b/comment/views.py
@@ -74,7 +74,6 @@ class CommentRetrieveUpdateDestroyAPI(generics.RetrieveUpdateDestroyAPIView):
 
 class ProcessCommentLikeAPI(APIView):
     authentication_classes = [JWTAuthentication,]
-    permission_classes = [IsOwnerOrReadOnly,]
 
     def post(self, request, *args, **kwargs):
         like, created = Like.objects.get_or_create(
@@ -91,7 +90,6 @@ class ProcessCommentLikeAPI(APIView):
 class ReplyListCreateAPI(generics.ListCreateAPIView):
     serializer_class = ReplySerializer
     authentication_classes = [JWTAuthentication, ]
-    permission_classes = [IsOwnerOrReadOnly, ]
     pagination_class = ReplyCursorPagination
 
     def get_queryset(self):
@@ -118,7 +116,6 @@ class ReplyRetrieveUpdateDestroyAPI(generics.RetrieveUpdateDestroyAPIView):
 
 class ProcessReplyLikeAPI(APIView):
     authentication_classes = [JWTAuthentication,]
-    permission_classes = [IsOwnerOrReadOnly,]
 
     def post(self, request, *args, **kwargs):
         like, created = Like.objects.get_or_create(

--- a/content/views.py
+++ b/content/views.py
@@ -18,6 +18,7 @@ from decimal import Decimal
 
 class MovieListAPI(generics.ListAPIView):
     serializer_class = MovieListSerializer
+    authentication_classes = [JWTAuthentication, ]
 
     def get_queryset(self, *args, **kwargs):
         if self.request.query_params.get('order'):
@@ -33,6 +34,7 @@ class MovieRetrieveAPI(generics.RetrieveAPIView):
     model = Movie
     queryset = Movie.objects.all()
     serializer_class = MovieSerializer
+    authentication_classes = [JWTAuthentication, ]
 
 
 class RatingAPI(generics.ListCreateAPIView):
@@ -66,6 +68,13 @@ class RatingAPI(generics.ListCreateAPIView):
                 movie=movie
             )
 
+            # connect Rating to Comment if exists
+            if Comment.objects.filter(movie=movie, created_by=self.request.user).exists():
+                user_comment = Comment.objects.get(movie=movie, created_by=self.request.user)
+                current_rating = Rating.objects.get(movie=movie, created_by=self.request.user)
+                user_comment.rating = current_rating
+                user_comment.save()
+
 
 class RatingRetrieveUpdateDestroyAPI(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = RatingSerializer
@@ -77,6 +86,7 @@ class RatingRetrieveUpdateDestroyAPI(generics.RetrieveUpdateDestroyAPIView):
 class CarouselRetrieveAPI(generics.RetrieveAPIView):
     queryset = Carousel.objects.all()
     serializer_class = CarouselSerializer
+    authentication_classes = [JWTAuthentication, ]
 
 
 class StateCreateAPI(generics.CreateAPIView):


### PR DESCRIPTION
변경사항:

- 영화 정보를 조회, Like 처리시에 authentication_class를 기본값(SessionAuthentication)에서 안바꿔놓아서 발생하는 문제들을 해결했습니다.

- ReplyListCreate의 경우 permission_class가 Owner인지를 확인하기보다는 Authenticated 되어있는지 확인하는 것이 더 알맞아보여, 삭제했습니다. settings.py에 permission_class 기본값이 IsAuthenticatedOrReadOnly로 되어있기에 별도로 permission_class를 지정해주지는 않았습니다.

- Comment와 Rating이 자동으로 연결되는 로직이 없어, 추가했습니다.

- Reply 시리얼라이저에서 현재 로그인된 계정이 좋아요를 눌렀는지 확인할 수 있도록 필드를 추가했습니다